### PR TITLE
Update repository URL for Flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: 5.8.0
     hooks:
     -   id: isort
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/PyCQA/flake8
     rev: 3.9.0
     hooks:
     -   id: flake8


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos